### PR TITLE
Changed the Test macro to prevent duplicate test names

### DIFF
--- a/gidunit.h
+++ b/gidunit.h
@@ -2179,6 +2179,8 @@ void _gid_test_suite_func_##suite_name()                                      \
  *          }
  * */
 #define Test(test_name, ...)                                                  \
+        void* gid_test_##test_name = NULL;/*Unused var to force unique names*/\
+        (void)gid_test_##test_name;                                           \
         _gid_end_previous_test_scope                                          \
         _gid_start_next_test_scope(test_name)                                 \
         GIDParamBase* _gid_int_row_params = NULL;                             \


### PR DESCRIPTION
Added a local variable based on the name of the test, thus preventing two tests in the same suite from having the same name. This resolves issue #7 